### PR TITLE
Reject requests from inactive users.

### DIFF
--- a/src/main/java/org/desarrolladorslp/technovation/config/auth/AuthorizationServerConfig.java
+++ b/src/main/java/org/desarrolladorslp/technovation/config/auth/AuthorizationServerConfig.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import javax.sql.DataSource;
 
 import org.desarrolladorslp.technovation.config.auth.firebase.FirebaseTokenGranter;
+import org.desarrolladorslp.technovation.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +35,8 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
     private JwtConfig jwtConfig;
 
     private DataSource dataSource;
+
+    private UserService userService;
 
     @Override
     public void configure(AuthorizationServerSecurityConfigurer security) {
@@ -66,7 +69,7 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
             return null;
         }
 
-        JwtAccessTokenConverter accessTokenConverter = new CustomJwtAccessTokenConverter();
+        JwtAccessTokenConverter accessTokenConverter = new CustomJwtAccessTokenConverter(userService);
         byte[] privateKey = Base64Utils.decodeFromString(jwtConfig.getPrivateKey());
         byte[] publicKey = Base64Utils.decodeFromString(jwtConfig.getPublicKey());
 
@@ -105,5 +108,10 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
     @Autowired
     public void setDataSource(DataSource dataSource) {
         this.dataSource = dataSource;
+    }
+
+    @Autowired
+    public void setUserService(UserService userService) {
+        this.userService = userService;
     }
 }

--- a/src/main/java/org/desarrolladorslp/technovation/config/auth/CustomJwtAccessTokenConverter.java
+++ b/src/main/java/org/desarrolladorslp/technovation/config/auth/CustomJwtAccessTokenConverter.java
@@ -12,22 +12,23 @@ public class CustomJwtAccessTokenConverter extends JwtAccessTokenConverter {
 
     private UserService userService;
 
-    public CustomJwtAccessTokenConverter(UserService userService) {
+    CustomJwtAccessTokenConverter(UserService userService) {
         this.userService = userService;
     }
 
+    @Override
     public OAuth2Authentication extractAuthentication(Map<String, ?> map) {
         OAuth2Authentication authentication = getAccessTokenConverter().extractAuthentication(map);
 
-        TokenInfo tokenInfo = new TokenInfo();
+        TokenInfo tokenInfo = TokenInfo.builder()
+                .userId((String) map.get(AdditionalJWTInformation.USER_ID_KEY))
+                .enabled((Boolean) map.get(AdditionalJWTInformation.ENABLED_KEY))
+                .validated((Boolean) map.get(AdditionalJWTInformation.VALIDATED_KEY))
+                .uid((String) map.get(AdditionalJWTInformation.USER_NAME_KEY))
+                .clientId((String) map.get(AdditionalJWTInformation.CLIENT_ID_KEY))
+                .build();
 
-        tokenInfo.setUserId((String) map.get(AdditionalJWTInformation.USER_ID_KEY));
-        tokenInfo.setEnabled((Boolean) map.get(AdditionalJWTInformation.ENABLED_KEY));
-        tokenInfo.setValidated((Boolean) map.get(AdditionalJWTInformation.VALIDATED_KEY));
-        tokenInfo.setUid((String) map.get(AdditionalJWTInformation.USER_NAME_KEY));
-        tokenInfo.setClientId((String) map.get(AdditionalJWTInformation.CLIENT_ID_KEY));
-
-        if(tokenInfo.isEnabled() && tokenInfo.isValidated()){
+        if (tokenInfo.isEnabled() && tokenInfo.isValidated()) {
             User user = userService.findById(UUID.fromString(tokenInfo.getUserId()));
 
             tokenInfo.setEnabled(user.isEnabled());

--- a/src/main/java/org/desarrolladorslp/technovation/config/auth/CustomJwtAccessTokenConverter.java
+++ b/src/main/java/org/desarrolladorslp/technovation/config/auth/CustomJwtAccessTokenConverter.java
@@ -1,23 +1,40 @@
 package org.desarrolladorslp.technovation.config.auth;
 
 import java.util.Map;
+import java.util.UUID;
 
+import org.desarrolladorslp.technovation.models.User;
+import org.desarrolladorslp.technovation.services.UserService;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
 
 public class CustomJwtAccessTokenConverter extends JwtAccessTokenConverter {
+
+    private UserService userService;
+
+    public CustomJwtAccessTokenConverter(UserService userService) {
+        this.userService = userService;
+    }
+
     public OAuth2Authentication extractAuthentication(Map<String, ?> map) {
         OAuth2Authentication authentication = getAccessTokenConverter().extractAuthentication(map);
 
         TokenInfo tokenInfo = new TokenInfo();
 
-        tokenInfo.setEmail((String) map.get(AdditionalJWTInformation.EMAIL_KEY));
-        tokenInfo.setName((String) map.get(AdditionalJWTInformation.NAME_KEY));
-        tokenInfo.setUid((String) map.get(AdditionalJWTInformation.USER_NAME_KEY));
+        tokenInfo.setUserId((String) map.get(AdditionalJWTInformation.USER_ID_KEY));
         tokenInfo.setEnabled((Boolean) map.get(AdditionalJWTInformation.ENABLED_KEY));
         tokenInfo.setValidated((Boolean) map.get(AdditionalJWTInformation.VALIDATED_KEY));
+        tokenInfo.setUid((String) map.get(AdditionalJWTInformation.USER_NAME_KEY));
         tokenInfo.setClientId((String) map.get(AdditionalJWTInformation.CLIENT_ID_KEY));
-        tokenInfo.setUserId((String) map.get(AdditionalJWTInformation.USER_ID_KEY));
+
+        if(tokenInfo.isEnabled() && tokenInfo.isValidated()){
+            User user = userService.findById(UUID.fromString(tokenInfo.getUserId()));
+
+            tokenInfo.setEnabled(user.isEnabled());
+            tokenInfo.setValidated(user.isValidated());
+            tokenInfo.setEmail(user.getPreferredEmail());
+            tokenInfo.setName(user.getName());
+        }
 
         authentication.setDetails(tokenInfo);
 

--- a/src/main/java/org/desarrolladorslp/technovation/config/auth/TokenInfo.java
+++ b/src/main/java/org/desarrolladorslp/technovation/config/auth/TokenInfo.java
@@ -1,5 +1,10 @@
 package org.desarrolladorslp.technovation.config.auth;
 
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
 public class TokenInfo {
     private String clientId;
     private String email;
@@ -8,56 +13,4 @@ public class TokenInfo {
     private String userId;
     private boolean enabled;
     private boolean validated;
-
-    public String getClientId() {
-        return clientId;
-    }
-
-    public void setClientId(String clientId) {
-        this.clientId = clientId;
-    }
-
-    public String getUserId() { return userId; }
-
-    public void setUserId(String userId) { this.userId = userId; }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getUid() {
-        return uid;
-    }
-
-    public void setUid(String uid) {
-        this.uid = uid;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public boolean isValidated() {
-        return validated;
-    }
-
-    public void setValidated(boolean validated) {
-        this.validated = validated;
-    }
 }

--- a/src/main/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilter.java
+++ b/src/main/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilter.java
@@ -1,36 +1,64 @@
 package org.desarrolladorslp.technovation.config.auth;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.desarrolladorslp.technovation.config.controller.MainExceptionHandler;
 import org.desarrolladorslp.technovation.exception.InactiveUserException;
 import org.desarrolladorslp.technovation.exception.InvalidUserException;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
+import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.google.gson.Gson;
+
 public class UserStatusFilter extends OncePerRequestFilter {
+
+    private Gson gson = new Gson();
 
     @Override
     protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
 
-        if (SecurityContextHolder.getContext().getAuthentication() instanceof OAuth2AuthenticationDetails) {
-            OAuth2AuthenticationDetails details = (OAuth2AuthenticationDetails) SecurityContextHolder.getContext().getAuthentication().getDetails();
-            TokenInfo tokenInfo = (TokenInfo) details.getDecodedDetails();
+        try {
+            if (SecurityContextHolder.getContext().getAuthentication() instanceof OAuth2Authentication) {
+                OAuth2AuthenticationDetails details = (OAuth2AuthenticationDetails) SecurityContextHolder.getContext().getAuthentication().getDetails();
+                TokenInfo tokenInfo = (TokenInfo) details.getDecodedDetails();
 
-            if (!tokenInfo.isEnabled()) {
-                throw new InactiveUserException("Inactive user");
-            }
+                if (!tokenInfo.isValidated()) {
+                    throw new InvalidUserException("User needs to be validated by administrators");
+                }
 
-            if (!tokenInfo.isValidated()) {
-                throw new InvalidUserException("User needs to be validated by administrators");
+                if (!tokenInfo.isEnabled()) {
+                    throw new InactiveUserException("Inactive user");
+                }
             }
+        } catch (InactiveUserException | InvalidUserException ex) {
+            prepareErrorResponse(ex, HttpStatus.FORBIDDEN, httpServletResponse);
+            return;
         }
 
         filterChain.doFilter(httpServletRequest, httpServletResponse);
+    }
+
+    private void prepareErrorResponse(Exception ex, HttpStatus status, HttpServletResponse response) throws IOException {
+        response.setContentType(MimeTypeUtils.APPLICATION_JSON_VALUE);
+        response.setStatus(status.value());
+
+        try (OutputStream os = response.getOutputStream()) {
+            MainExceptionHandler.Error error = new MainExceptionHandler.Error()
+                    .message(ex.getMessage())
+                    .exception(ex.getClass().getCanonicalName());
+
+            os.write(gson.toJson(error).getBytes(StandardCharsets.UTF_8));
+        }
     }
 }

--- a/src/main/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilter.java
+++ b/src/main/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilter.java
@@ -13,6 +13,7 @@ import org.desarrolladorslp.technovation.config.controller.MainExceptionHandler;
 import org.desarrolladorslp.technovation.exception.InactiveUserException;
 import org.desarrolladorslp.technovation.exception.InvalidUserException;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
@@ -29,8 +30,9 @@ public class UserStatusFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
 
         try {
-            if (SecurityContextHolder.getContext().getAuthentication() instanceof OAuth2Authentication) {
-                OAuth2AuthenticationDetails details = (OAuth2AuthenticationDetails) SecurityContextHolder.getContext().getAuthentication().getDetails();
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication instanceof OAuth2Authentication) {
+                OAuth2AuthenticationDetails details = (OAuth2AuthenticationDetails) authentication.getDetails();
                 TokenInfo tokenInfo = (TokenInfo) details.getDecodedDetails();
 
                 if (!tokenInfo.isValidated()) {

--- a/src/main/java/org/desarrolladorslp/technovation/config/auth/fake/FakeFirebaseService.java
+++ b/src/main/java/org/desarrolladorslp/technovation/config/auth/fake/FakeFirebaseService.java
@@ -27,12 +27,12 @@ public class FakeFirebaseService implements FirebaseService {
         }
 
         FakeToken fakeToken = tokens.get(idToken);
-        TokenInfo token = new TokenInfo();
 
-        token.setEmail(fakeToken.getEmail());
-        token.setName(fakeToken.getName());
-        token.setUid(idToken);
+        return TokenInfo.builder()
+                .email(fakeToken.getEmail())
+                .name(fakeToken.getName())
+                .uid(idToken)
+                .build();
 
-        return token;
     }
 }

--- a/src/main/java/org/desarrolladorslp/technovation/config/auth/firebase/FirebaseServiceImpl.java
+++ b/src/main/java/org/desarrolladorslp/technovation/config/auth/firebase/FirebaseServiceImpl.java
@@ -23,13 +23,13 @@ public class FirebaseServiceImpl implements FirebaseService {
 
         try {
             FirebaseToken token = FirebaseAuth.getInstance().verifyIdToken(firebaseToken);
-            TokenInfo tokenInfo = new TokenInfo();
 
-            tokenInfo.setUid(token.getUid());
-            tokenInfo.setName(token.getName());
-            tokenInfo.setEmail(token.getEmail());
+            return TokenInfo.builder()
+                    .uid(token.getUid())
+                    .name(token.getName())
+                    .email(token.getEmail())
+                    .build();
 
-            return tokenInfo;
         } catch (Exception e) {
             throw new FirebaseTokenInvalidException(e.getMessage());
         }

--- a/src/main/java/org/desarrolladorslp/technovation/config/controller/MainExceptionHandler.java
+++ b/src/main/java/org/desarrolladorslp/technovation/config/controller/MainExceptionHandler.java
@@ -40,12 +40,12 @@ public class MainExceptionHandler {
         String message;
         String exception;
 
-        Error message(String message) {
+        public Error message(String message) {
             this.message = message;
             return this;
         }
 
-        Error exception(String exception) {
+        public Error exception(String exception) {
             this.exception = exception;
             return this;
         }

--- a/src/test/java/org/desarrolladorslp/technovation/config/auth/CustomJwtAccessTokenConverterTest.java
+++ b/src/test/java/org/desarrolladorslp/technovation/config/auth/CustomJwtAccessTokenConverterTest.java
@@ -1,0 +1,149 @@
+package org.desarrolladorslp.technovation.config.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.desarrolladorslp.technovation.config.auth.AdditionalJWTInformation.CLIENT_ID_KEY;
+import static org.desarrolladorslp.technovation.config.auth.AdditionalJWTInformation.EMAIL_KEY;
+import static org.desarrolladorslp.technovation.config.auth.AdditionalJWTInformation.ENABLED_KEY;
+import static org.desarrolladorslp.technovation.config.auth.AdditionalJWTInformation.NAME_KEY;
+import static org.desarrolladorslp.technovation.config.auth.AdditionalJWTInformation.USER_ID_KEY;
+import static org.desarrolladorslp.technovation.config.auth.AdditionalJWTInformation.VALIDATED_KEY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.desarrolladorslp.technovation.models.User;
+import org.desarrolladorslp.technovation.services.UserService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CustomJwtAccessTokenConverterTest {
+
+    @Test
+    public void extractAuthenticationForNotEnabledAndNotValidatedUsers() {
+        extractAuthenticationTestingEnabledAndValidatedFlags(false, false);
+    }
+
+    @Test
+    public void extractAuthenticationForNotEnabledAndValidatedUsers() {
+        extractAuthenticationTestingEnabledAndValidatedFlags(false, true);
+    }
+
+    @Test
+    public void extractAuthenticationForEnabledAndNotValidatedUsers() {
+        extractAuthenticationTestingEnabledAndValidatedFlags(true, false);
+    }
+
+    @Test
+    public void extractAuthenticationForEnabledAndValidatedUsers() {
+        extractAuthenticationForEnabledAndValidatedUsers(true, true);
+    }
+
+    @Test
+    public void extractAuthenticationForNotEnabledAndValidatedUsersInDBUser() {
+        extractAuthenticationForEnabledAndValidatedUsers(false, false);
+    }
+
+    @Test
+    public void extractAuthenticationForEnabledAndNotValidatedUsersInDBUser() {
+        extractAuthenticationForEnabledAndValidatedUsers(false, true);
+    }
+
+    @Test
+    public void extractAuthenticationForNotEnabledAndNotValidatedUsersInDBUser() {
+        extractAuthenticationForEnabledAndValidatedUsers(false, false);
+    }
+
+    public void extractAuthenticationForEnabledAndValidatedUsers(boolean enabled, boolean validated) {
+        // Given:
+        UserService mockUserService = mock(UserService.class);
+        AccessTokenConverter mockAccessTokenConverter = mock(AccessTokenConverter.class);
+        CustomJwtAccessTokenConverter tokenConverter = new CustomJwtAccessTokenConverter(mockUserService);
+        Map<String, Object> mapWithTokenInfo = prepareMapWithAuthenticationInfo();
+        OAuth2Authentication authentication = mock(OAuth2Authentication.class);
+        User user = User.builder()
+                .name(UUID.randomUUID().toString())
+                .preferredEmail(UUID.randomUUID().toString())
+                .validated(validated)
+                .enabled(enabled)
+                .build();
+
+        mapWithTokenInfo.put(ENABLED_KEY, true);
+        mapWithTokenInfo.put(VALIDATED_KEY, true);
+
+        TokenInfo tokenInfo = TokenInfo.builder()
+                .clientId((String) mapWithTokenInfo.get(CLIENT_ID_KEY))
+                .userId((String) mapWithTokenInfo.get(USER_ID_KEY))
+                .enabled(user.isEnabled())
+                .validated(user.isValidated())
+                .name(user.getName())
+                .email(user.getPreferredEmail())
+                .build();
+
+        tokenConverter.setAccessTokenConverter(mockAccessTokenConverter);
+        when(mockAccessTokenConverter.extractAuthentication(mapWithTokenInfo)).thenReturn(authentication);
+        UUID userUUID = UUID.fromString(tokenInfo.getUserId());
+        when(mockUserService.findById(userUUID)).thenReturn(user);
+
+        // When:
+        OAuth2Authentication receivedAuthentication = tokenConverter.extractAuthentication(mapWithTokenInfo);
+
+        //Then:
+        verify(authentication).setDetails(tokenInfo);
+        verify(mockUserService).findById(userUUID);
+        verifyZeroInteractions(mockUserService);
+        assertThat(receivedAuthentication).isEqualTo(authentication);
+
+    }
+
+    private void extractAuthenticationTestingEnabledAndValidatedFlags(boolean enabled, boolean validated) {
+        // Given:
+        UserService mockUserService = mock(UserService.class);
+        AccessTokenConverter mockAccessTokenConverter = mock(AccessTokenConverter.class);
+        CustomJwtAccessTokenConverter tokenConverter = new CustomJwtAccessTokenConverter(mockUserService);
+        Map<String, Object> mapWithTokenInfo = prepareMapWithAuthenticationInfo();
+        OAuth2Authentication authentication = mock(OAuth2Authentication.class);
+
+        mapWithTokenInfo.put(ENABLED_KEY, enabled);
+        mapWithTokenInfo.put(VALIDATED_KEY, validated);
+
+        TokenInfo tokenInfo = TokenInfo.builder()
+                .clientId((String) mapWithTokenInfo.get(CLIENT_ID_KEY))
+                .userId((String) mapWithTokenInfo.get(USER_ID_KEY))
+                .enabled(enabled)
+                .validated(validated)
+                .build();
+
+        tokenConverter.setAccessTokenConverter(mockAccessTokenConverter);
+        when(mockAccessTokenConverter.extractAuthentication(mapWithTokenInfo)).thenReturn(authentication);
+
+        // When:
+        OAuth2Authentication receivedAuthentication = tokenConverter.extractAuthentication(mapWithTokenInfo);
+
+        //Then:
+        verify(authentication).setDetails(tokenInfo);
+        verifyZeroInteractions(mockUserService);
+        assertThat(receivedAuthentication).isEqualTo(authentication);
+
+    }
+
+    private Map<String, Object> prepareMapWithAuthenticationInfo() {
+        Map<String, Object> map = new HashMap<>();
+
+        map.put(EMAIL_KEY, UUID.randomUUID().toString());
+        map.put(NAME_KEY, UUID.randomUUID().toString());
+        map.put(USER_ID_KEY, UUID.randomUUID().toString());
+        map.put(CLIENT_ID_KEY, UUID.randomUUID().toString());
+
+        return map;
+    }
+
+}

--- a/src/test/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilterTest.java
+++ b/src/test/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilterTest.java
@@ -15,6 +15,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.desarrolladorslp.technovation.config.controller.MainExceptionHandler;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -33,6 +35,17 @@ import com.google.gson.Gson;
 public class UserStatusFilterTest {
 
     private Gson gson = new Gson();
+    private SecurityContext realSecurityContext;
+
+    @Before
+    public void setup() {
+        realSecurityContext = SecurityContextHolder.getContext();
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.setContext(realSecurityContext);
+    }
 
     @Test
     public void whenUserInactiveReturn403() throws ServletException, IOException {
@@ -48,12 +61,8 @@ public class UserStatusFilterTest {
         ServletOutputStream mockServletOutputStream = mock(ServletOutputStream.class);
         FilterChain mockFilterChain = mock(FilterChain.class);
 
-        TokenInfo tokenInfo = new TokenInfo();
+        TokenInfo tokenInfo = TokenInfo.builder().enabled(false).validated(false).build();
         ArgumentCaptor<byte[]> responsePayload = ArgumentCaptor.forClass(byte[].class);
-
-
-        tokenInfo.setEnabled(false);
-        tokenInfo.setValidated(false);
 
         when(mockSecurityContext.getAuthentication()).thenReturn(mockAuthentication);
         SecurityContextHolder.setContext(mockSecurityContext);
@@ -95,11 +104,8 @@ public class UserStatusFilterTest {
         ServletOutputStream mockServletOutputStream = mock(ServletOutputStream.class);
         FilterChain mockFilterChain = mock(FilterChain.class);
 
-        TokenInfo tokenInfo = new TokenInfo();
+        TokenInfo tokenInfo = TokenInfo.builder().enabled(false).validated(true).build();
         ArgumentCaptor<byte[]> responsePayload = ArgumentCaptor.forClass(byte[].class);
-
-        tokenInfo.setEnabled(false);
-        tokenInfo.setValidated(true);
 
         when(mockSecurityContext.getAuthentication()).thenReturn(mockAuthentication);
         SecurityContextHolder.setContext(mockSecurityContext);
@@ -141,10 +147,7 @@ public class UserStatusFilterTest {
         ServletOutputStream mockServletOutputStream = mock(ServletOutputStream.class);
         FilterChain mockFilterChain = mock(FilterChain.class);
 
-        TokenInfo tokenInfo = new TokenInfo();
-
-        tokenInfo.setEnabled(true);
-        tokenInfo.setValidated(true);
+        TokenInfo tokenInfo = TokenInfo.builder().enabled(true).validated(true).build();
 
         when(mockSecurityContext.getAuthentication()).thenReturn(mockAuthentication);
         SecurityContextHolder.setContext(mockSecurityContext);

--- a/src/test/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilterTest.java
+++ b/src/test/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilterTest.java
@@ -1,0 +1,159 @@
+package org.desarrolladorslp.technovation.config.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.desarrolladorslp.technovation.config.controller.MainExceptionHandler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
+import org.springframework.util.MimeTypeUtils;
+
+import com.google.gson.Gson;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserStatusFilterTest {
+
+    private Gson gson = new Gson();
+
+    @Test
+    public void whenUserInactiveReturn403() throws ServletException, IOException {
+
+        // Given:
+        UserStatusFilter userStatusFilter = new UserStatusFilter();
+
+        OAuth2AuthenticationDetails mockDetails = mock(OAuth2AuthenticationDetails.class);
+        Authentication mockAuthentication = mock(OAuth2Authentication.class);
+        SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        ServletOutputStream mockServletOutputStream = mock(ServletOutputStream.class);
+        FilterChain mockFilterChain = mock(FilterChain.class);
+
+        TokenInfo tokenInfo = new TokenInfo();
+        ArgumentCaptor<byte[]> responsePayload = ArgumentCaptor.forClass(byte[].class);
+
+
+        tokenInfo.setEnabled(false);
+        tokenInfo.setValidated(false);
+
+        when(mockSecurityContext.getAuthentication()).thenReturn(mockAuthentication);
+        SecurityContextHolder.setContext(mockSecurityContext);
+        when(mockAuthentication.getDetails()).thenReturn(mockDetails);
+        when(mockDetails.getDecodedDetails()).thenReturn(tokenInfo);
+        when(mockResponse.getOutputStream()).thenReturn(mockServletOutputStream);
+
+        // When:\
+        userStatusFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+        verify(mockSecurityContext).getAuthentication();
+        verify(mockAuthentication).getDetails();
+        verify(mockResponse).setContentType(MimeTypeUtils.APPLICATION_JSON_VALUE);
+        verify(mockResponse).setStatus(HttpStatus.FORBIDDEN.value());
+        verify(mockResponse).getOutputStream();
+        verify(mockServletOutputStream).write(responsePayload.capture());
+        verify(mockServletOutputStream).close();
+        verify(mockDetails).getDecodedDetails();
+        verifyZeroInteractions(mockDetails, mockAuthentication, mockSecurityContext, mockRequest, mockResponse, mockServletOutputStream, mockFilterChain);
+
+        MainExceptionHandler.Error error = gson.fromJson(new String(responsePayload.getValue()), MainExceptionHandler.Error.class);
+
+        assertThat(error).extracting("message").containsExactly("User needs to be validated by administrators");
+        assertThat(error).extracting("exception").containsExactly("org.desarrolladorslp.technovation.exception.InvalidUserException");
+    }
+
+    @Test
+    public void whenUserNotEnabledReturn403() throws ServletException, IOException {
+
+        // Given:
+        UserStatusFilter userStatusFilter = new UserStatusFilter();
+
+        OAuth2AuthenticationDetails mockDetails = mock(OAuth2AuthenticationDetails.class);
+        Authentication mockAuthentication = mock(OAuth2Authentication.class);
+        SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        ServletOutputStream mockServletOutputStream = mock(ServletOutputStream.class);
+        FilterChain mockFilterChain = mock(FilterChain.class);
+
+        TokenInfo tokenInfo = new TokenInfo();
+        ArgumentCaptor<byte[]> responsePayload = ArgumentCaptor.forClass(byte[].class);
+
+
+        tokenInfo.setEnabled(false);
+        tokenInfo.setValidated(true);
+
+        when(mockSecurityContext.getAuthentication()).thenReturn(mockAuthentication);
+        SecurityContextHolder.setContext(mockSecurityContext);
+        when(mockAuthentication.getDetails()).thenReturn(mockDetails);
+        when(mockDetails.getDecodedDetails()).thenReturn(tokenInfo);
+        when(mockResponse.getOutputStream()).thenReturn(mockServletOutputStream);
+
+        // When:\
+        userStatusFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+        verify(mockSecurityContext).getAuthentication();
+        verify(mockAuthentication).getDetails();
+        verify(mockResponse).setContentType(MimeTypeUtils.APPLICATION_JSON_VALUE);
+        verify(mockResponse).setStatus(HttpStatus.FORBIDDEN.value());
+        verify(mockResponse).getOutputStream();
+        verify(mockServletOutputStream).write(responsePayload.capture());
+        verify(mockServletOutputStream).close();
+        verify(mockDetails).getDecodedDetails();
+        verifyZeroInteractions(mockDetails, mockAuthentication, mockSecurityContext, mockRequest, mockResponse, mockServletOutputStream, mockFilterChain);
+
+        MainExceptionHandler.Error error = gson.fromJson(new String(responsePayload.getValue()), MainExceptionHandler.Error.class);
+
+        assertThat(error).extracting("message").containsExactly("Inactive user");
+        assertThat(error).extracting("exception").containsExactly("org.desarrolladorslp.technovation.exception.InactiveUserException");
+    }
+
+    @Test
+    public void whenUserEnabledAndValidatedThenSuccess() throws ServletException, IOException {
+
+        // Given:
+        UserStatusFilter userStatusFilter = new UserStatusFilter();
+
+        OAuth2AuthenticationDetails mockDetails = mock(OAuth2AuthenticationDetails.class);
+        Authentication mockAuthentication = mock(OAuth2Authentication.class);
+        SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        ServletOutputStream mockServletOutputStream = mock(ServletOutputStream.class);
+        FilterChain mockFilterChain = mock(FilterChain.class);
+
+        TokenInfo tokenInfo = new TokenInfo();
+
+        tokenInfo.setEnabled(true);
+        tokenInfo.setValidated(true);
+
+        when(mockSecurityContext.getAuthentication()).thenReturn(mockAuthentication);
+        SecurityContextHolder.setContext(mockSecurityContext);
+        when(mockAuthentication.getDetails()).thenReturn(mockDetails);
+        when(mockDetails.getDecodedDetails()).thenReturn(tokenInfo);
+
+        // When:\
+        userStatusFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+        verify(mockSecurityContext).getAuthentication();
+        verify(mockAuthentication).getDetails();
+        verify(mockDetails).getDecodedDetails();
+        verify(mockFilterChain).doFilter(mockRequest, mockResponse);
+        verifyZeroInteractions(mockDetails, mockAuthentication, mockSecurityContext, mockRequest, mockResponse, mockServletOutputStream, mockFilterChain);
+    }
+}

--- a/src/test/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilterTest.java
+++ b/src/test/java/org/desarrolladorslp/technovation/config/auth/UserStatusFilterTest.java
@@ -61,8 +61,10 @@ public class UserStatusFilterTest {
         when(mockDetails.getDecodedDetails()).thenReturn(tokenInfo);
         when(mockResponse.getOutputStream()).thenReturn(mockServletOutputStream);
 
-        // When:\
+        // When:
         userStatusFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+
+        // Then:
         verify(mockSecurityContext).getAuthentication();
         verify(mockAuthentication).getDetails();
         verify(mockResponse).setContentType(MimeTypeUtils.APPLICATION_JSON_VALUE);
@@ -96,7 +98,6 @@ public class UserStatusFilterTest {
         TokenInfo tokenInfo = new TokenInfo();
         ArgumentCaptor<byte[]> responsePayload = ArgumentCaptor.forClass(byte[].class);
 
-
         tokenInfo.setEnabled(false);
         tokenInfo.setValidated(true);
 
@@ -106,8 +107,10 @@ public class UserStatusFilterTest {
         when(mockDetails.getDecodedDetails()).thenReturn(tokenInfo);
         when(mockResponse.getOutputStream()).thenReturn(mockServletOutputStream);
 
-        // When:\
+        // When:
         userStatusFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+
+        // Then:
         verify(mockSecurityContext).getAuthentication();
         verify(mockAuthentication).getDetails();
         verify(mockResponse).setContentType(MimeTypeUtils.APPLICATION_JSON_VALUE);
@@ -148,8 +151,10 @@ public class UserStatusFilterTest {
         when(mockAuthentication.getDetails()).thenReturn(mockDetails);
         when(mockDetails.getDecodedDetails()).thenReturn(tokenInfo);
 
-        // When:\
+        // When:
         userStatusFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+
+        // Then:
         verify(mockSecurityContext).getAuthentication();
         verify(mockAuthentication).getDetails();
         verify(mockDetails).getDecodedDetails();


### PR DESCRIPTION
In this PR I fixed UserStatusFilter so it can reject with a 403 the operations requested by not enabled or not validated users.

Also it includes a change in CustomJwtAccessTokenConverter to read the user from database if the token indicates that it is enabled and validated to avoid issues letting disabled or invalid users access the application because the token is outdated. 